### PR TITLE
Replace Expo NavTalk assets with gradient fallback

### DIFF
--- a/ExpoNavTalk/App.tsx
+++ b/ExpoNavTalk/App.tsx
@@ -1,0 +1,402 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Dimensions,
+  FlatList,
+  Image,
+  ImageBackground,
+  Platform,
+  SafeAreaView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { StatusBar as ExpoStatusBar } from 'expo-status-bar';
+import MaskedView from '@react-native-masked-view/masked-view';
+import NetInfo from '@react-native-community/netinfo';
+import { MaterialIcons } from '@expo/vector-icons';
+
+const { height } = Dimensions.get('window');
+
+const CHARACTER_NAME = 'navtalk.Leo';
+const REMOTE_BACKGROUND = `https://api.navtalk.ai/uploadFiles/${CHARACTER_NAME}.png`;
+const FALLBACK_BACKGROUND_COLORS = ['#1a1a1a', '#050505'];
+
+const CONNECTING_DELAY_MS = 1600;
+const MESSAGE_INTERVAL_MS = 2400;
+
+type NavTalkStatus = 'notConnected' | 'connecting' | 'connected';
+
+type Message = {
+  id: string;
+  type: 'question' | 'answer';
+  content: string;
+};
+
+const SAMPLE_CONVERSATION: Message[] = [
+  {
+    id: 'answer-greeting',
+    type: 'answer',
+    content: "Hi there! I'm Leo with NavTalk. I can see and hear you perfectly."
+  },
+  {
+    id: 'question-capabilities',
+    type: 'question',
+    content: 'Great! Could you walk me through what you can help with during a call?'
+  },
+  {
+    id: 'answer-capabilities',
+    type: 'answer',
+    content:
+      'Absolutely. I manage the real-time conversation, keep context, and surface relevant knowledge instantly while we talk.'
+  },
+  {
+    id: 'question-adapt',
+    type: 'question',
+    content: 'How quickly can you adjust if I change topics or ask something unexpected?'
+  },
+  {
+    id: 'answer-adapt',
+    type: 'answer',
+    content:
+      'NavTalk adapts on the fly. The underlying model listens continuously and pivots the dialogue in under a second.'
+  },
+  {
+    id: 'question-summary',
+    type: 'question',
+    content: 'Nice. Could you summarise what we have covered so far?'
+  },
+  {
+    id: 'answer-summary',
+    type: 'answer',
+    content:
+      'Sure thing! We established the connection, reviewed my role in guiding the call, and highlighted how fast I adjust. '
+  },
+  {
+    id: 'question-wrap',
+    type: 'question',
+    content: "Thanks Leo—that's all I needed for now."
+  },
+  {
+    id: 'answer-wrap',
+    type: 'answer',
+    content: 'Happy to help! Feel free to reconnect any time you want to dive deeper.'
+  }
+];
+
+const isNativePlatform = Platform.OS === 'ios' || Platform.OS === 'android';
+
+export default function App() {
+  const [status, setStatus] = useState<NavTalkStatus>('notConnected');
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [backgroundUri, setBackgroundUri] = useState<string | null>(REMOTE_BACKGROUND);
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const listRef = useRef<FlatList<Message>>(null);
+
+  const messageAreaHeight = useMemo(() => Math.min(height * 0.55, 450), []);
+  const gradientColors = useMemo(() => ['rgba(0,0,0,0.88)', 'rgba(0,0,0,0)'], []);
+
+  const clearTimers = useCallback(() => {
+    timers.current.forEach((timer) => clearTimeout(timer));
+    timers.current = [];
+  }, []);
+
+  const fetchRemoteBackground = useCallback(async () => {
+    try {
+      const success = await Image.prefetch(REMOTE_BACKGROUND);
+      if (success) {
+        setBackgroundUri(REMOTE_BACKGROUND);
+      } else {
+        setBackgroundUri(null);
+      }
+    } catch (error) {
+      setBackgroundUri(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRemoteBackground();
+  }, [fetchRemoteBackground]);
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      if (state.isConnected && state.isInternetReachable) {
+        fetchRemoteBackground();
+      }
+    });
+
+    return () => unsubscribe();
+  }, [fetchRemoteBackground]);
+
+  useEffect(() => {
+    return () => clearTimers();
+  }, [clearTimers]);
+
+  useEffect(() => {
+    if (messages.length === 0) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      listRef.current?.scrollToEnd({ animated: true });
+    });
+  }, [messages]);
+
+  const scheduleConversation = useCallback(() => {
+    SAMPLE_CONVERSATION.forEach((message, index) => {
+      const timer = setTimeout(() => {
+        setMessages((prev) => {
+          if (prev.find((item) => item.id === message.id)) {
+            return prev;
+          }
+
+          return [...prev, { ...message }];
+        });
+      }, index * MESSAGE_INTERVAL_MS);
+
+      timers.current.push(timer);
+    });
+  }, []);
+
+  const handleStartCall = useCallback(() => {
+    if (status !== 'notConnected') {
+      return;
+    }
+
+    clearTimers();
+    setMessages([]);
+    setStatus('connecting');
+
+    const connectingTimer = setTimeout(() => {
+      setStatus('connected');
+      scheduleConversation();
+    }, CONNECTING_DELAY_MS);
+
+    timers.current.push(connectingTimer);
+  }, [clearTimers, scheduleConversation, status]);
+
+  const handleHangUp = useCallback(() => {
+    setStatus('notConnected');
+    setMessages([]);
+    clearTimers();
+  }, [clearTimers]);
+
+  const renderMessage = useCallback(({ item }: { item: Message }) => {
+    const isQuestion = item.type === 'question';
+    const bubbleStyle = isQuestion ? styles.questionBubble : styles.answerBubble;
+    const containerStyle = isQuestion ? styles.questionContainer : styles.answerContainer;
+
+    return (
+      <View style={[styles.messageRow, containerStyle]}>
+        <View style={[styles.messageBubble, bubbleStyle]}>
+          <Text style={styles.messageText}>{item.content}</Text>
+        </View>
+      </View>
+    );
+  }, []);
+
+  const keyExtractor = useCallback((item: Message) => item.id, []);
+
+  const messageList = (
+    <FlatList
+      ref={listRef}
+      data={messages}
+      keyExtractor={keyExtractor}
+      renderItem={renderMessage}
+      contentContainerStyle={styles.messageListContent}
+      style={styles.messageList}
+    />
+  );
+
+  const renderControls = () => {
+    if (status === 'notConnected') {
+      return (
+        <TouchableOpacity
+          style={[styles.controlButton, styles.callButton]}
+          onPress={handleStartCall}
+          activeOpacity={0.85}
+        >
+          <MaterialIcons name="call" size={18} color="#FFFFFF" style={styles.controlIcon} />
+          <Text style={styles.controlText}>Call</Text>
+        </TouchableOpacity>
+      );
+    }
+
+    if (status === 'connecting') {
+      return (
+        <View style={[styles.controlButton, styles.connectingButton]}>
+          <ActivityIndicator color="#FFFFFF" size="small" style={styles.controlSpinner} />
+          <Text style={styles.controlText}>Connecting…</Text>
+        </View>
+      );
+    }
+
+    return (
+      <TouchableOpacity
+        style={[styles.controlButton, styles.hangupButton]}
+        onPress={handleHangUp}
+        activeOpacity={0.85}
+      >
+        <MaterialIcons name="call-end" size={18} color="#FFFFFF" style={styles.controlIcon} />
+        <Text style={styles.controlText}>Hang Up</Text>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderConversationContent = () => (
+    <>
+      <LinearGradient colors={gradientColors} style={styles.gradientBackdrop} pointerEvents="none" />
+      <View style={styles.contentArea}>
+        {isNativePlatform ? (
+          <MaskedView
+            style={[styles.messageMaskWrapper, { height: messageAreaHeight }]}
+            maskElement={
+              <LinearGradient
+                colors={["rgba(0,0,0,0)", 'rgba(0,0,0,1)']}
+                start={{ x: 0.5, y: 0 }}
+                end={{ x: 0.5, y: 1 }}
+                style={StyleSheet.absoluteFill}
+              />
+            }
+          >
+            <View style={styles.messageMaskContent}>{messageList}</View>
+          </MaskedView>
+        ) : (
+          <View style={[styles.messageMaskWrapper, { height: messageAreaHeight }]}>{messageList}</View>
+        )}
+        <View style={styles.controlsContainer}>{renderControls()}</View>
+      </View>
+    </>
+  );
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar barStyle={Platform.OS === 'ios' ? 'light-content' : 'default'} />
+      <ExpoStatusBar style="light" />
+      {backgroundUri ? (
+        <ImageBackground
+          source={{ uri: backgroundUri, cache: 'reload' }}
+          style={styles.background}
+          resizeMode="cover"
+          onError={() => setBackgroundUri(null)}
+        >
+          <View style={styles.overlay}>{renderConversationContent()}</View>
+        </ImageBackground>
+      ) : (
+        <LinearGradient colors={FALLBACK_BACKGROUND_COLORS} style={styles.background}>
+          <View style={styles.overlay}>{renderConversationContent()}</View>
+        </LinearGradient>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#000'
+  },
+  background: {
+    flex: 1
+  },
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.35)'
+  },
+  gradientBackdrop: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: height * 0.6
+  },
+  contentArea: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    paddingHorizontal: 20,
+    paddingBottom: 32,
+    paddingTop: 16,
+    gap: 24
+  },
+  messageMaskWrapper: {
+    width: '100%'
+  },
+  messageMaskContent: {
+    flex: 1
+  },
+  messageList: {
+    flex: 1
+  },
+  messageListContent: {
+    flexGrow: 1,
+    justifyContent: 'flex-end',
+    paddingTop: 24,
+    paddingBottom: 16,
+    gap: 12
+  },
+  messageRow: {
+    width: '100%',
+    flexDirection: 'row'
+  },
+  questionContainer: {
+    justifyContent: 'flex-end'
+  },
+  answerContainer: {
+    justifyContent: 'flex-start'
+  },
+  messageBubble: {
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 8,
+    maxWidth: '78%'
+  },
+  questionBubble: {
+    backgroundColor: 'rgba(108,105,170,0.95)'
+  },
+  answerBubble: {
+    backgroundColor: 'rgba(40,40,38,0.95)'
+  },
+  messageText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    lineHeight: 22
+  },
+  controlsContainer: {
+    alignItems: 'center'
+  },
+  controlButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 20,
+    paddingVertical: 12,
+    paddingHorizontal: 20
+  },
+  callButton: {
+    backgroundColor: 'rgba(121,121,242,1)',
+    minWidth: 120
+  },
+  connectingButton: {
+    backgroundColor: 'rgba(245,29,72,1)',
+    opacity: 0.35,
+    minWidth: 150
+  },
+  hangupButton: {
+    backgroundColor: 'rgba(245,29,72,1)',
+    minWidth: 135
+  },
+  controlText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600'
+  },
+  controlIcon: {
+    marginRight: 8
+  },
+  controlSpinner: {
+    marginRight: 10
+  }
+});

--- a/ExpoNavTalk/README.md
+++ b/ExpoNavTalk/README.md
@@ -1,0 +1,24 @@
+# NavTalk Expo Demo
+
+This Expo application recreates the conversational experience demonstrated in the native iOS sample. The layout mirrors the
+original UIKit implementation with a full-screen background image, gradient-masked transcript list, and contextual call
+controls that transition between **Call**, **Connecting**, and **Hang Up** states.
+
+Key touches carried over from the iOS build include:
+
+- Loading the Leo character background from the same NavTalk CDN with automatic fallback to an on-device gradient when the
+  network is unavailable.
+- A gradient mask on the transcript list so recent messages fade into the background just like the UITableView mask.
+- Distinct call controls for each NavTalk status, complete with iconography and the translucent connecting state.
+- A scripted question/answer exchange that echoes the flow you see in the native project.
+
+## Getting started
+
+```bash
+cd ExpoNavTalk
+npm install
+npm start
+```
+
+When you press **Call**, the demo simulates a WebRTC session. After a brief connecting state the scripted conversation flows in
+real time, alternating between question and answer bubbles exactly as it does in the UIKit experience.

--- a/ExpoNavTalk/app.json
+++ b/ExpoNavTalk/app.json
@@ -1,0 +1,27 @@
+{
+  "expo": {
+    "name": "NavTalk Expo Demo",
+    "slug": "navtalk-expo-demo",
+    "scheme": "navtalk",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "automatic",
+    "splash": {
+      "backgroundColor": "#000000"
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "backgroundColor": "#000000"
+      }
+    },
+    "web": {
+      "bundler": "metro"
+    }
+  }
+}

--- a/ExpoNavTalk/babel.config.js
+++ b/ExpoNavTalk/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin']
+  };
+};

--- a/ExpoNavTalk/package.json
+++ b/ExpoNavTalk/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "exponavtalk",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "@react-native-community/netinfo": "11.2.1",
+    "@react-native-masked-view/masked-view": "0.3.4",
+    "expo": "~51.0.14",
+    "expo-linear-gradient": "~13.0.3",
+    "expo-status-bar": "~1.12.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.74.3",
+    "react-native-gesture-handler": "~2.16.1",
+    "react-native-reanimated": "~3.10.1",
+    "react-native-safe-area-context": "4.10.1",
+    "react-native-screens": "~3.31.1",
+    "react-native-svg": "15.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "7.20.0",
+    "@types/react": "18.2.79",
+    "@types/react-native": "0.72.5",
+    "typescript": "5.3.3"
+  }
+}

--- a/ExpoNavTalk/tsconfig.json
+++ b/ExpoNavTalk/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "react",
+    "lib": ["dom", "es2017"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["react", "react-native"]
+  },
+  "include": ["**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- switch the Expo NavTalk screen to use a gradient fallback when the CDN background is unavailable, removing the need for bundled PNG assets
- refactor the shared conversation layout into a reusable render helper so the gradient overlay applies to both the remote and fallback backgrounds
- drop icon and splash image references from app.json and update the README to describe the gradient-based offline state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ebcc05741c832e9a1992c62312bd8f