### PR TITLE
Translate Chinese comments to English

### DIFF
--- a/HtmlClient/demo.js
+++ b/HtmlClient/demo.js
@@ -850,7 +850,7 @@ async function initDigtalHumanHistoryData(){
   const historyStr = localStorage.getItem("realtimeChatHistory");
   realtimeChatHistory = historyStr ? JSON.parse(historyStr) : [];
 
-  // 进入页面，渲染历史对话记录
+  // Render the historical conversation when the page loads
   if (realtimeChatHistory && realtimeChatHistory.length > 0) {
     realtimeChatHistory.forEach(item => {
       appendContentToList(item.role, item.content);

--- a/WebServer/demo.html
+++ b/WebServer/demo.html
@@ -1229,7 +1229,7 @@
         const historyStr = localStorage.getItem("realtimeChatHistory");
         realtimeChatHistory = historyStr ? JSON.parse(historyStr) : [];
 
-        // 进入页面，渲染历史对话记录
+        // Render the historical conversation when the page loads
         if (realtimeChatHistory && realtimeChatHistory.length > 0) {
             realtimeChatHistory.forEach(item => {
                 appendContentToList(item.role, item.content);

--- a/iOS/NavTalk/Models/Model/RecordAudioManager.swift
+++ b/iOS/NavTalk/Models/Model/RecordAudioManager.swift
@@ -81,7 +81,7 @@ class RecordAudioManager: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate
         AudioUnitSetProperty(audioUnit,
                              kAudioUnitProperty_StreamFormat,
                              kAudioUnitScope_Output,
-                             1, // 输入bus
+                             1, // Input bus
                              &audioFormat,
                              UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
         )


### PR DESCRIPTION
## Summary
- translate chat history rendering comments in the HTML and JS demos into English
- update the audio manager input bus comment to English for clarity

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ebd20b47a4832eae6e057ce8e491a0