### PR TITLE
Add demo video references to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ cd Samples
 - **API Documentation** – [NavTalk API Documentation](https://navtalk.gitbook.io/api)
 - **License** – [MIT License](https://opensource.org/licenses/MIT)
 
+## Demo Videos
+
+- [NavTalk Platform Overview](https://www.youtube.com/watch?v=YoyZqpvqzPE)
+- [NavTalk In-depth Walkthrough](https://www.youtube.com/watch?v=ja3YgHNaPWc)
+
 Need help? Visit the [support portal](https://navtalk.ai/support/) or consult the [API documentation](https://navtalk.gitbook.io/api) for detailed guides and troubleshooting tips.
 
 


### PR DESCRIPTION
## Summary
- add a dedicated Demo Videos section to the README
- link to two YouTube walkthroughs of the NavTalk platform

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebd4bc9818832eb9c7b08d599de957