### PR TITLE
Add Discord community link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ cd Samples
 
 - **Official Website** – <a href="https://www.navtalk.ai" target="_blank" rel="noopener noreferrer">navtalk.ai</a>
 - **API Documentation** – <a href="https://navtalk.gitbook.io/api" target="_blank" rel="noopener noreferrer">NavTalk API Documentation</a>
+- **Community Discord** – <a href="https://discord.gg/A9VE3zXM9p" target="_blank" rel="noopener noreferrer">Join the NavTalk Discord</a>
 - **License** – <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener noreferrer">MIT License</a>
 
 ## Demo Videos


### PR DESCRIPTION
## Summary
- add a link to the NavTalk community Discord in the documentation and support section of the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec52ad5df8832e8333d99d0990dda1